### PR TITLE
Server volume and improved docker stop.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
-FROM alpine:3.10.3
-
-COPY docker-entrypoint.sh /usr/local/bin/
+FROM alpine:3.12.0
 
 RUN apk --update upgrade 
-
 RUN apk add --no-cache openjdk10
-
 RUN apk add --no-cache screen
 
 RUN mkdir /minecraft
 
-RUN  wget -O /minecraft/minecraft_server.jar https://launcher.mojang.com/v1/objects/a412fd69db1f81db3f511c1463fd304675244077/server.jar
+# Minecraft Java Edition Server ver. 1.16.2.
+RUN wget -O /minecraft_server.jar https://launcher.mojang.com/v1/objects/c5f6fb23c3876461d46ec380421e42b289789530/server.jar
 
-ENTRYPOINT (screen -d -m sh /usr/local/bin/docker-entrypoint.sh) && sh
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apk add --no-cache openjdk10
 
 RUN apk add --no-cache screen
 
-RUN  wget -O minecraft_server.jar https://launcher.mojang.com/v1/objects/a412fd69db1f81db3f511c1463fd304675244077/server.jar
+RUN mkdir /minecraft
+
+RUN  wget -O /minecraft/minecraft_server.jar https://launcher.mojang.com/v1/objects/a412fd69db1f81db3f511c1463fd304675244077/server.jar
 
 ENTRYPOINT (screen -d -m sh /usr/local/bin/docker-entrypoint.sh) && sh

--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ Omitting the `-t 90` flag might corrupt the world.
 ```
 Don't forget about the `-t 90` flag.
 
+## Acknowledgements
 Thanks for the response [here](https://unix.stackexchange.com/questions/13953/sending-text-input-to-a-detached-screen) on convenient GNU Screen usage.
 Thanks to **Hynek Schlawack** for his [post](https://hynek.me/articles/docker-signals/) on capturing signals inside Docker containers.

--- a/README.md
+++ b/README.md
@@ -1,59 +1,32 @@
 # simple_mc_server
-A simplified minecraft server creation
+A simple **Minecraft Java Edition Server** container.
 
-## Create and start minecraft server
-```sh
-sudo docker run -it -d -p 25565:25565 --name mcsv frienddementor/simple_mc_server
+## Running the container
+```
+# docker run --name mcsv \
+  --publish 25565:25565 \
+  --volume minecraft:/minecraft \
+  -d frienddementor/simple_mc_server
 ```
 
-## Enter to minecraft server console
-```sh
-sudo docker exec -it mcsv screen -x
+## Enter the server console
 ```
-**IMPORTANT NOTE:** To exit without close the server press
-**Ctrl+A** and later **D**
-
-## Backup world
-Assuming the minecraft server is stopped
-```sh
-# compress the world folder
-sudo docker exec -it mcsv tar -czvf bu.tar.gz world
-
-# copy the compresed file to host with the actual date
-sudo docker cp mcsv:/bu.tar.gz $(date '+%Y-%m-%d-%H-%M-%S')-backup.tar.gz
-
-# remove the compresed file of the container
-sudo docker exec -it mcsv rm bu.tar.gz
+# docker exec -it mcsv screen -x
 ```
+**IMPORTANT NOTE:** To exit the console without closing the server, detach from it by pressing
+**Ctrl+a** and then **d**.
 
-## Restore backup
-Assuming the minecraft server is stopped
-Assuming the world folder don't exists
-```sh
-# copy the backup file to container
-sudo docker cp 1970-01-01-00-00-01-backup.tar.gz mcsv:/bu.tar.gz
-
-# extract
-sudo docker exec -it mcsv tar -xzvf bu.tar.gz
-
-# remove the compresed file of the container
-sudo docker exec -it mcsv rm bu.tar.gz
+## Stopping the container
 ```
-
-
-## Restart the server
-
-```sh
-# stop the mc server
-sudo docker exec -it mcsv screen -p 0 -X stuff "stop^M"
-
-# stop the container
-sudo docker stop mcsv
-
-# start the container
-sudo docker start mcsv
+# docker stop -t 90 mcsv
 ```
-The mc server will start automatically by the entrypoint when the container start
+Omitting the `-t 90` flag might corrupt the world.
 
+## Restarting the container
+```
+# docker restart -t 90 mcsv
+```
+Don't forget about the `-t 90` flag.
 
-Thanks for the response [here](https://unix.stackexchange.com/questions/13953/sending-text-input-to-a-detached-screen)
+Thanks for the response [here](https://unix.stackexchange.com/questions/13953/sending-text-input-to-a-detached-screen) on convenient GNU Screen usage.
+Thanks to **Hynek Schlawack** for his [post](https://hynek.me/articles/docker-signals/) on capturing signals inside Docker containers.

--- a/contributors.txt
+++ b/contributors.txt
@@ -1,2 +1,3 @@
 vanninipablo@gmail.com
+agna.lumi@protonmail.com
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,4 @@
-echo Hello world
-
+echo Docker is love, Docker is life.
+cd /minecraft
 echo eula=true > eula.txt
-
 java -Xmx1024M -Xms1024M -jar minecraft_server.jar nogui
-
-echo By world

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,36 @@
-echo Docker is love, Docker is life.
-cd /minecraft
-echo eula=true > eula.txt
-java -Xmx1024M -Xms1024M -jar minecraft_server.jar nogui
+#!/bin/sh
+
+# This function checks whether GNU screen exited gracefully.
+server_wait()
+{
+	while [ true ]
+	do
+		if [ -f "serv_stop" ]; then
+			rm serv_stop
+			break
+		fi
+		sleep 1
+	done
+}
+
+cleanup()
+{
+	echo "Shutting down..."
+	screen -p 0 -X stuff "stop$(echo -ne '\r')"
+	server_wait
+	echo "Graceful shutdown."
+	kill -s SIGINT 1
+}
+trap "cleanup" SIGTERM 	# Triggers "cleanup" on "docker stop."
+
+cd minecraft
+
+if [ ! -f minecraft_server.jar ]; then
+	cp ../minecraft_server.jar .
+fi
+
+echo eula=true > eula.txt 	# Signing EULA is required to launch the Minecraft server.
+screen -d -m sh -c "echo 'Docker is love, Docker is life.' && java -Xmx1024M -Xms1024M -jar minecraft_server.jar nogui && echo 1 > serv_stop" 	# The echo is used by server_wait.
+sleep infinity &
+
+wait $!


### PR DESCRIPTION
This setup allows `-v minecraft/minecraft` flag to be used when running the image. This creates a volume that exposes the server files to the user for easier configuration.

Running `docker stop <image>` sends a `stop` command to the screen window to shutdown the server gracefully. A delay of 90 seconds is recommended in the README.md so as to avoid Minecraft world corruption.

The image has an updated version of Minecraft server (1.16.2).